### PR TITLE
Domain: Shop CRUD use cases

### DIFF
--- a/domain/src/commonMain/kotlin/com/shopforge/domain/model/ShopWithInventory.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/model/ShopWithInventory.kt
@@ -1,0 +1,9 @@
+package com.shopforge.domain.model
+
+/**
+ * A shop paired with its current inventory.
+ */
+data class ShopWithInventory(
+    val shop: Shop,
+    val inventory: List<ShopInventoryItem>,
+)

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/AddItemToShopUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/AddItemToShopUseCase.kt
@@ -23,6 +23,7 @@ class AddItemToShopUseCase(
         quantity: Int?,
         adjustedPrice: Price,
     ) {
+        require(quantity == null || quantity >= 0) { "Quantity cannot be negative. Got: $quantity" }
         shopRepository.addItemToShop(
             shopId = shopId,
             item = item,

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/AddItemToShopUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/AddItemToShopUseCase.kt
@@ -1,0 +1,33 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.repository.ShopRepository
+
+/**
+ * Adds an item (catalog or custom) to a shop's inventory with a given
+ * quantity and adjusted price.
+ */
+class AddItemToShopUseCase(
+    private val shopRepository: ShopRepository,
+) {
+    /**
+     * @param shopId The shop to add the item to.
+     * @param item The item to add.
+     * @param quantity Stock quantity, or null for unlimited stock.
+     * @param adjustedPrice The price for this item in this shop.
+     */
+    suspend operator fun invoke(
+        shopId: Long,
+        item: Item,
+        quantity: Int?,
+        adjustedPrice: Price,
+    ) {
+        shopRepository.addItemToShop(
+            shopId = shopId,
+            item = item,
+            quantity = quantity,
+            adjustedPrice = adjustedPrice,
+        )
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/CreateShopUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/CreateShopUseCase.kt
@@ -1,0 +1,41 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Shop
+import com.shopforge.domain.model.ShopType
+import com.shopforge.domain.repository.ShopRepository
+
+/**
+ * Creates a new shop with the given name, type, and optional description.
+ * The shop is created with an empty inventory.
+ *
+ * Business rules:
+ * - Shop name must not be blank.
+ * - Shop type is required (enforced by the non-nullable parameter).
+ */
+class CreateShopUseCase(
+    private val shopRepository: ShopRepository,
+    private val clock: () -> Long,
+) {
+    /**
+     * @return The generated ID of the newly created shop.
+     * @throws IllegalArgumentException if [name] is blank.
+     */
+    suspend operator fun invoke(
+        name: String,
+        type: ShopType,
+        description: String? = null,
+    ): Long {
+        require(name.isNotBlank()) { "Shop name must not be blank" }
+
+        val now = clock()
+        val shop = Shop(
+            id = 0,
+            name = name.trim(),
+            type = type,
+            description = description?.trim()?.ifEmpty { null },
+            createdAt = now,
+            updatedAt = now,
+        )
+        return shopRepository.createShop(shop)
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/DecrementQuantityUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/DecrementQuantityUseCase.kt
@@ -1,0 +1,40 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.flow.first
+
+/**
+ * Decrements an item's quantity by 1 in a shop's inventory.
+ *
+ * Business rules:
+ * - Null quantity (unlimited stock) is a no-op.
+ * - Quantity at 0 (sold out) is a no-op.
+ * - Otherwise, quantity is decremented by 1.
+ */
+class DecrementQuantityUseCase(
+    private val shopRepository: ShopRepository,
+) {
+    /**
+     * @param shopId The shop containing the item.
+     * @param itemId The item whose quantity to decrement.
+     */
+    suspend operator fun invoke(shopId: Long, itemId: Long) {
+        val inventory = shopRepository.getInventory(shopId).first()
+        val inventoryItem = inventory.find { it.item.id == itemId } ?: return
+
+        val currentQuantity = inventoryItem.quantity
+
+        // Unlimited stock (null) -> no-op
+        if (currentQuantity == null) return
+
+        // Already sold out (0) -> no-op
+        if (currentQuantity <= 0) return
+
+        // Decrement by 1
+        shopRepository.updateItemQuantity(
+            shopId = shopId,
+            itemId = itemId,
+            quantity = currentQuantity - 1,
+        )
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/DeleteShopUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/DeleteShopUseCase.kt
@@ -1,0 +1,14 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.repository.ShopRepository
+
+/**
+ * Deletes a shop and its inventory.
+ */
+class DeleteShopUseCase(
+    private val shopRepository: ShopRepository,
+) {
+    suspend operator fun invoke(shopId: Long) {
+        shopRepository.deleteShop(shopId)
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/GetAllShopsUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/GetAllShopsUseCase.kt
@@ -1,0 +1,16 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Shop
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Retrieves all shops as a reactive Flow for the shop list screen.
+ */
+class GetAllShopsUseCase(
+    private val shopRepository: ShopRepository,
+) {
+    operator fun invoke(): Flow<List<Shop>> {
+        return shopRepository.getAllShops()
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCase.kt
@@ -1,0 +1,32 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Shop
+import com.shopforge.domain.model.ShopInventoryItem
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+/**
+ * Retrieves a single shop along with its full inventory as a reactive Flow.
+ * Emits null if the shop does not exist.
+ */
+class GetShopWithInventoryUseCase(
+    private val shopRepository: ShopRepository,
+) {
+    operator fun invoke(shopId: Long): Flow<ShopWithInventory?> {
+        return combine(
+            shopRepository.getShopById(shopId),
+            shopRepository.getInventory(shopId),
+        ) { shop, inventory ->
+            shop?.let { ShopWithInventory(it, inventory) }
+        }
+    }
+}
+
+/**
+ * A shop paired with its current inventory.
+ */
+data class ShopWithInventory(
+    val shop: Shop,
+    val inventory: List<ShopInventoryItem>,
+)

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCase.kt
@@ -1,7 +1,6 @@
 package com.shopforge.domain.usecase
 
-import com.shopforge.domain.model.Shop
-import com.shopforge.domain.model.ShopInventoryItem
+import com.shopforge.domain.model.ShopWithInventory
 import com.shopforge.domain.repository.ShopRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -22,11 +21,3 @@ class GetShopWithInventoryUseCase(
         }
     }
 }
-
-/**
- * A shop paired with its current inventory.
- */
-data class ShopWithInventory(
-    val shop: Shop,
-    val inventory: List<ShopInventoryItem>,
-)

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/RegenerateInventoryUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/RegenerateInventoryUseCase.kt
@@ -1,0 +1,27 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.flow.first
+
+/**
+ * Clears a shop's existing inventory and replaces it with a freshly
+ * generated set of items based on the shop's type.
+ *
+ * Delegates inventory generation to [GenerateInventoryUseCase].
+ */
+class RegenerateInventoryUseCase(
+    private val shopRepository: ShopRepository,
+    private val generateInventoryUseCase: GenerateInventoryUseCase,
+) {
+    /**
+     * @param shopId The shop whose inventory to regenerate.
+     * @throws NoSuchElementException if no shop with [shopId] exists.
+     */
+    suspend operator fun invoke(shopId: Long) {
+        val shop = shopRepository.getShopById(shopId).first()
+            ?: throw NoSuchElementException("Shop with id $shopId not found")
+
+        val newInventory = generateInventoryUseCase(shop.type)
+        shopRepository.replaceInventory(shopId, newInventory)
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/RemoveItemFromShopUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/RemoveItemFromShopUseCase.kt
@@ -1,0 +1,14 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.repository.ShopRepository
+
+/**
+ * Removes an item from a shop's inventory.
+ */
+class RemoveItemFromShopUseCase(
+    private val shopRepository: ShopRepository,
+) {
+    suspend operator fun invoke(shopId: Long, itemId: Long) {
+        shopRepository.removeItemFromShop(shopId = shopId, itemId = itemId)
+    }
+}

--- a/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/UpdateShopUseCase.kt
+++ b/domain/src/commonMain/kotlin/com/shopforge/domain/usecase/UpdateShopUseCase.kt
@@ -1,0 +1,41 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.flow.first
+
+/**
+ * Updates an existing shop's name, type, and/or description.
+ *
+ * Business rules:
+ * - Shop name must not be blank.
+ * - Shop type is required.
+ */
+class UpdateShopUseCase(
+    private val shopRepository: ShopRepository,
+    private val clock: () -> Long,
+) {
+    /**
+     * @throws IllegalArgumentException if [name] is blank.
+     * @throws NoSuchElementException if no shop with [shopId] exists.
+     */
+    suspend operator fun invoke(
+        shopId: Long,
+        name: String,
+        type: ShopType,
+        description: String? = null,
+    ) {
+        require(name.isNotBlank()) { "Shop name must not be blank" }
+
+        val existing = shopRepository.getShopById(shopId).first()
+            ?: throw NoSuchElementException("Shop with id $shopId not found")
+
+        val updated = existing.copy(
+            name = name.trim(),
+            type = type,
+            description = description?.trim()?.ifEmpty { null },
+            updatedAt = clock(),
+        )
+        shopRepository.updateShop(updated)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/AddItemToShopUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/AddItemToShopUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+
+class AddItemToShopUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val useCase = AddItemToShopUseCase(repository)
+
+    @Test
+    fun `adds item to shop inventory`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem()
+        val adjustedPrice = Price.ofGold(16)
+
+        useCase(shopId, item, 5, adjustedPrice)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(1, inventory.size)
+        assertEquals(item, inventory[0].item)
+        assertEquals(5, inventory[0].quantity)
+        assertEquals(adjustedPrice, inventory[0].adjustedPrice)
+    }
+
+    @Test
+    fun `adds item with unlimited quantity`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Tavern)
+        val item = TestFixtures.sampleItem()
+
+        useCase(shopId, item, null, item.price)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertNull(inventory[0].quantity)
+    }
+
+    @Test
+    fun `adds multiple different items`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.GeneralStore)
+        val item1 = TestFixtures.sampleItem(id = 1L, name = "Rope")
+        val item2 = TestFixtures.sampleItem(id = 2L, name = "Torch")
+
+        useCase(shopId, item1, 10, item1.price)
+        useCase(shopId, item2, 20, item2.price)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(2, inventory.size)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/CreateShopUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/CreateShopUseCaseTest.kt
@@ -1,0 +1,89 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class CreateShopUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val useCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+
+    @Test
+    fun `creates shop with name, type, and description`() = runTest {
+        val id = useCase("The Gilded Anvil", ShopType.Blacksmith, "A fine smithy")
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertEquals("The Gilded Anvil", shop.name)
+        assertEquals(ShopType.Blacksmith, shop.type)
+        assertEquals("A fine smithy", shop.description)
+        assertEquals(TestFixtures.FIXED_TIME, shop.createdAt)
+        assertEquals(TestFixtures.FIXED_TIME, shop.updatedAt)
+    }
+
+    @Test
+    fun `creates shop without description`() = runTest {
+        val id = useCase("Magic Emporium", ShopType.MagicShop)
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertNull(shop.description)
+    }
+
+    @Test
+    fun `trims shop name`() = runTest {
+        val id = useCase("  Padded Name  ", ShopType.GeneralStore)
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertEquals("Padded Name", shop.name)
+    }
+
+    @Test
+    fun `empty description becomes null`() = runTest {
+        val id = useCase("Shop", ShopType.Tavern, description = "")
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertNull(shop.description)
+    }
+
+    @Test
+    fun `whitespace-only description becomes null`() = runTest {
+        val id = useCase("Shop", ShopType.Tavern, description = "   ")
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertNull(shop.description)
+    }
+
+    @Test
+    fun `blank name throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            useCase("", ShopType.Blacksmith)
+        }
+    }
+
+    @Test
+    fun `whitespace-only name throws IllegalArgumentException`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            useCase("   ", ShopType.Blacksmith)
+        }
+    }
+
+    @Test
+    fun `shop is created with empty inventory`() = runTest {
+        val id = useCase("Empty Shop", ShopType.GeneralStore)
+
+        assertTrue(repository.getInventorySnapshot(id).isEmpty())
+    }
+
+    @Test
+    fun `returns generated shop id`() = runTest {
+        val id1 = useCase("Shop 1", ShopType.Blacksmith)
+        val id2 = useCase("Shop 2", ShopType.Tavern)
+
+        assertTrue(id1 > 0)
+        assertTrue(id2 > id1)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/DecrementQuantityUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/DecrementQuantityUseCaseTest.kt
@@ -1,0 +1,97 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+
+class DecrementQuantityUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val addItemUseCase = AddItemToShopUseCase(repository)
+    private val useCase = DecrementQuantityUseCase(repository)
+
+    @Test
+    fun `decrements quantity by 1`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 5, item.price)
+
+        useCase(shopId, item.id)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(4, inventory[0].quantity)
+    }
+
+    @Test
+    fun `decrements from 1 to 0`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 1, item.price)
+
+        useCase(shopId, item.id)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(0, inventory[0].quantity)
+    }
+
+    @Test
+    fun `quantity 0 is a no-op`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 0, item.price)
+
+        useCase(shopId, item.id)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(0, inventory[0].quantity)
+    }
+
+    @Test
+    fun `unlimited stock (null quantity) is a no-op`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Tavern)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, null, item.price)
+
+        useCase(shopId, item.id)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertNull(inventory[0].quantity)
+    }
+
+    @Test
+    fun `nonexistent item is a no-op`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+
+        useCase(shopId, 999L) // Should complete without error
+    }
+
+    @Test
+    fun `multiple decrements work correctly`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 3, item.price)
+
+        useCase(shopId, item.id) // 3 -> 2
+        useCase(shopId, item.id) // 2 -> 1
+        useCase(shopId, item.id) // 1 -> 0
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(0, inventory[0].quantity)
+    }
+
+    @Test
+    fun `decrement at 0 stays at 0 after multiple calls`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 0, item.price)
+
+        useCase(shopId, item.id)
+        useCase(shopId, item.id)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(0, inventory[0].quantity)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/DeleteShopUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/DeleteShopUseCaseTest.kt
@@ -1,0 +1,40 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class DeleteShopUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val addItemUseCase = AddItemToShopUseCase(repository)
+    private val useCase = DeleteShopUseCase(repository)
+
+    @Test
+    fun `deletes existing shop`() = runTest {
+        val id = createUseCase("Doomed Shop", ShopType.Blacksmith)
+
+        useCase(id)
+
+        assertNull(repository.getShopSnapshot(id))
+    }
+
+    @Test
+    fun `deletes shop inventory along with shop`() = runTest {
+        val id = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem()
+        addItemUseCase(id, item, 5, item.price)
+
+        useCase(id)
+
+        assertTrue(repository.getInventorySnapshot(id).isEmpty())
+    }
+
+    @Test
+    fun `deleting nonexistent shop does not throw`() = runTest {
+        useCase(999L) // Should complete without error
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/FakeShopRepository.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/FakeShopRepository.kt
@@ -1,0 +1,102 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.Shop
+import com.shopforge.domain.model.ShopInventoryItem
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+/**
+ * In-memory fake of [ShopRepository] for unit testing use cases.
+ */
+class FakeShopRepository : ShopRepository {
+
+    private var nextShopId = 1L
+    private val shops = MutableStateFlow<Map<Long, Shop>>(emptyMap())
+    private val inventories = MutableStateFlow<Map<Long, List<ShopInventoryItem>>>(emptyMap())
+
+    override fun getAllShops(): Flow<List<Shop>> =
+        shops.map { it.values.toList() }
+
+    override fun getShopById(id: Long): Flow<Shop?> =
+        shops.map { it[id] }
+
+    override suspend fun createShop(shop: Shop): Long {
+        val id = nextShopId++
+        val saved = shop.copy(id = id)
+        shops.update { it + (id to saved) }
+        return id
+    }
+
+    override suspend fun updateShop(shop: Shop) {
+        shops.update { current ->
+            require(shop.id in current) { "Shop ${shop.id} not found" }
+            current + (shop.id to shop)
+        }
+    }
+
+    override suspend fun deleteShop(id: Long) {
+        shops.update { it - id }
+        inventories.update { it - id }
+    }
+
+    override fun getInventory(shopId: Long): Flow<List<ShopInventoryItem>> =
+        inventories.map { it[shopId] ?: emptyList() }
+
+    override suspend fun addItemToShop(
+        shopId: Long,
+        item: Item,
+        quantity: Int?,
+        adjustedPrice: Price,
+    ) {
+        inventories.update { current ->
+            val existing = current[shopId] ?: emptyList()
+            val existingEntry = existing.find { it.item.id == item.id }
+            val updated = if (existingEntry != null) {
+                val newQuantity = when {
+                    existingEntry.quantity == null || quantity == null -> null
+                    else -> existingEntry.quantity + quantity
+                }
+                existing.map {
+                    if (it.item.id == item.id) it.copy(quantity = newQuantity) else it
+                }
+            } else {
+                existing + ShopInventoryItem(item, quantity, adjustedPrice)
+            }
+            current + (shopId to updated)
+        }
+    }
+
+    override suspend fun removeItemFromShop(shopId: Long, itemId: Long) {
+        inventories.update { current ->
+            val existing = current[shopId] ?: return@update current
+            current + (shopId to existing.filter { it.item.id != itemId })
+        }
+    }
+
+    override suspend fun updateItemQuantity(shopId: Long, itemId: Long, quantity: Int?) {
+        inventories.update { current ->
+            val existing = current[shopId] ?: return@update current
+            current + (shopId to existing.map {
+                if (it.item.id == itemId) it.copy(quantity = quantity) else it
+            })
+        }
+    }
+
+    override suspend fun replaceInventory(shopId: Long, items: List<ShopInventoryItem>) {
+        inventories.update { current ->
+            current + (shopId to items)
+        }
+    }
+
+    // ---- Test helpers ----
+
+    fun getShopSnapshot(id: Long): Shop? = shops.value[id]
+
+    fun getInventorySnapshot(shopId: Long): List<ShopInventoryItem> =
+        inventories.value[shopId] ?: emptyList()
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/GetAllShopsUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/GetAllShopsUseCaseTest.kt
@@ -1,0 +1,32 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class GetAllShopsUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val useCase = GetAllShopsUseCase(repository)
+
+    @Test
+    fun `returns empty list when no shops exist`() = runTest {
+        val shops = useCase().first()
+        assertTrue(shops.isEmpty())
+    }
+
+    @Test
+    fun `returns all created shops`() = runTest {
+        createUseCase("Shop A", ShopType.Blacksmith)
+        createUseCase("Shop B", ShopType.Tavern)
+        createUseCase("Shop C", ShopType.MagicShop)
+
+        val shops = useCase().first()
+        assertEquals(3, shops.size)
+        assertEquals(setOf("Shop A", "Shop B", "Shop C"), shops.map { it.name }.toSet())
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class GetShopWithInventoryUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val addItemUseCase = AddItemToShopUseCase(repository)
+    private val useCase = GetShopWithInventoryUseCase(repository)
+
+    @Test
+    fun `returns null for nonexistent shop`() = runTest {
+        val result = useCase(999L).first()
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns shop with empty inventory`() = runTest {
+        val id = createUseCase("Empty Shop", ShopType.GeneralStore)
+
+        val result = useCase(id).first()
+        assertNotNull(result)
+        assertEquals("Empty Shop", result.shop.name)
+        assertTrue(result.inventory.isEmpty())
+    }
+
+    @Test
+    fun `returns shop with inventory items`() = runTest {
+        val id = createUseCase("Stocked Shop", ShopType.Blacksmith)
+        val item1 = TestFixtures.sampleItem(id = 1L, name = "Sword")
+        val item2 = TestFixtures.sampleItem(id = 2L, name = "Shield")
+        addItemUseCase(id, item1, 3, item1.price)
+        addItemUseCase(id, item2, null, item2.price)
+
+        val result = useCase(id).first()
+        assertNotNull(result)
+        assertEquals(2, result.inventory.size)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/GetShopWithInventoryUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.shopforge.domain.usecase
 
 import com.shopforge.domain.model.ShopType
+import com.shopforge.domain.model.ShopWithInventory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/RegenerateInventoryUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/RegenerateInventoryUseCaseTest.kt
@@ -1,0 +1,99 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.ShopInventoryItem
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+
+class RegenerateInventoryUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val addItemUseCase = AddItemToShopUseCase(repository)
+
+    @Test
+    fun `replaces existing inventory with generated items`() = runTest {
+        val shopId = createUseCase("Smithy", ShopType.Blacksmith)
+        val oldItem = TestFixtures.sampleItem(id = 1L, name = "Old Sword")
+        addItemUseCase(shopId, oldItem, 5, oldItem.price)
+
+        val generatedItems = listOf(
+            TestFixtures.sampleInventoryItem(
+                item = TestFixtures.sampleItem(id = 10L, name = "New Sword"),
+                quantity = 3,
+            ),
+            TestFixtures.sampleInventoryItem(
+                item = TestFixtures.sampleItem(id = 11L, name = "New Shield"),
+                quantity = 2,
+            ),
+        )
+
+        val fakeGenerator = object : GenerateInventoryUseCase {
+            override suspend fun invoke(shopType: ShopType): List<ShopInventoryItem> {
+                assertEquals(ShopType.Blacksmith, shopType)
+                return generatedItems
+            }
+        }
+
+        val useCase = RegenerateInventoryUseCase(repository, fakeGenerator)
+        useCase(shopId)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(2, inventory.size)
+        assertEquals("New Sword", inventory[0].item.name)
+        assertEquals("New Shield", inventory[1].item.name)
+    }
+
+    @Test
+    fun `uses shop type for generation`() = runTest {
+        val shopId = createUseCase("Magic Place", ShopType.MagicShop)
+        var capturedType: ShopType? = null
+
+        val fakeGenerator = object : GenerateInventoryUseCase {
+            override suspend fun invoke(shopType: ShopType): List<ShopInventoryItem> {
+                capturedType = shopType
+                return emptyList()
+            }
+        }
+
+        val useCase = RegenerateInventoryUseCase(repository, fakeGenerator)
+        useCase(shopId)
+
+        assertEquals(ShopType.MagicShop, capturedType)
+    }
+
+    @Test
+    fun `throws for nonexistent shop`() = runTest {
+        val fakeGenerator = object : GenerateInventoryUseCase {
+            override suspend fun invoke(shopType: ShopType): List<ShopInventoryItem> =
+                emptyList()
+        }
+
+        val useCase = RegenerateInventoryUseCase(repository, fakeGenerator)
+
+        assertFailsWith<NoSuchElementException> {
+            useCase(999L)
+        }
+    }
+
+    @Test
+    fun `clears inventory when generator returns empty list`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Tavern)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 5, item.price)
+
+        val fakeGenerator = object : GenerateInventoryUseCase {
+            override suspend fun invoke(shopType: ShopType): List<ShopInventoryItem> =
+                emptyList()
+        }
+
+        val useCase = RegenerateInventoryUseCase(repository, fakeGenerator)
+        useCase(shopId)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(0, inventory.size)
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/RemoveItemFromShopUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/RemoveItemFromShopUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class RemoveItemFromShopUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private val createUseCase = CreateShopUseCase(repository, clock = { TestFixtures.FIXED_TIME })
+    private val addItemUseCase = AddItemToShopUseCase(repository)
+    private val useCase = RemoveItemFromShopUseCase(repository)
+
+    @Test
+    fun `removes item from shop inventory`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item = TestFixtures.sampleItem(id = 1L)
+        addItemUseCase(shopId, item, 5, item.price)
+
+        useCase(shopId, item.id)
+
+        assertTrue(repository.getInventorySnapshot(shopId).isEmpty())
+    }
+
+    @Test
+    fun `only removes specified item, keeps others`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        val item1 = TestFixtures.sampleItem(id = 1L, name = "Sword")
+        val item2 = TestFixtures.sampleItem(id = 2L, name = "Shield")
+        addItemUseCase(shopId, item1, 3, item1.price)
+        addItemUseCase(shopId, item2, 5, item2.price)
+
+        useCase(shopId, item1.id)
+
+        val inventory = repository.getInventorySnapshot(shopId)
+        assertEquals(1, inventory.size)
+        assertEquals("Shield", inventory[0].item.name)
+    }
+
+    @Test
+    fun `removing nonexistent item does not throw`() = runTest {
+        val shopId = createUseCase("Shop", ShopType.Blacksmith)
+        useCase(shopId, 999L) // Should complete without error
+    }
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/TestFixtures.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/TestFixtures.kt
@@ -1,0 +1,41 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.Rarity
+import com.shopforge.domain.model.ShopInventoryItem
+
+/**
+ * Shared test fixtures for use case tests.
+ */
+object TestFixtures {
+
+    const val FIXED_TIME = 1_000_000L
+
+    fun sampleItem(
+        id: Long = 1L,
+        name: String = "Longsword",
+        category: ItemCategory = ItemCategory.Weapon,
+        price: Price = Price.ofGold(15),
+        rarity: Rarity = Rarity.Common,
+        isCustom: Boolean = false,
+    ) = Item(
+        id = id,
+        name = name,
+        category = category,
+        price = price,
+        rarity = rarity,
+        isCustom = isCustom,
+    )
+
+    fun sampleInventoryItem(
+        item: Item = sampleItem(),
+        quantity: Int? = 5,
+        adjustedPrice: Price = item.price,
+    ) = ShopInventoryItem(
+        item = item,
+        quantity = quantity,
+        adjustedPrice = adjustedPrice,
+    )
+}

--- a/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/UpdateShopUseCaseTest.kt
+++ b/domain/src/commonTest/kotlin/com/shopforge/domain/usecase/UpdateShopUseCaseTest.kt
@@ -1,0 +1,78 @@
+package com.shopforge.domain.usecase
+
+import com.shopforge.domain.model.ShopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+
+class UpdateShopUseCaseTest {
+
+    private val repository = FakeShopRepository()
+    private var currentTime = TestFixtures.FIXED_TIME
+    private val createUseCase = CreateShopUseCase(repository, clock = { currentTime })
+    private val useCase = UpdateShopUseCase(repository, clock = { currentTime })
+
+    @Test
+    fun `updates shop name, type, and description`() = runTest {
+        val id = createUseCase("Old Name", ShopType.Blacksmith, "Old desc")
+        currentTime += 1000
+
+        useCase(id, "New Name", ShopType.MagicShop, "New desc")
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertEquals("New Name", shop.name)
+        assertEquals(ShopType.MagicShop, shop.type)
+        assertEquals("New desc", shop.description)
+    }
+
+    @Test
+    fun `updates updatedAt timestamp`() = runTest {
+        val id = createUseCase("Shop", ShopType.Blacksmith)
+        currentTime += 5000
+
+        useCase(id, "Updated", ShopType.Blacksmith)
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertEquals(TestFixtures.FIXED_TIME, shop.createdAt)
+        assertEquals(TestFixtures.FIXED_TIME + 5000, shop.updatedAt)
+    }
+
+    @Test
+    fun `trims name and description`() = runTest {
+        val id = createUseCase("Shop", ShopType.Tavern)
+
+        useCase(id, "  Trimmed  ", ShopType.Tavern, "  Trimmed desc  ")
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertEquals("Trimmed", shop.name)
+        assertEquals("Trimmed desc", shop.description)
+    }
+
+    @Test
+    fun `empty description becomes null`() = runTest {
+        val id = createUseCase("Shop", ShopType.Tavern, "Has desc")
+
+        useCase(id, "Shop", ShopType.Tavern, description = "")
+
+        val shop = repository.getShopSnapshot(id)!!
+        assertNull(shop.description)
+    }
+
+    @Test
+    fun `blank name throws IllegalArgumentException`() = runTest {
+        val id = createUseCase("Shop", ShopType.Blacksmith)
+
+        assertFailsWith<IllegalArgumentException> {
+            useCase(id, "", ShopType.Blacksmith)
+        }
+    }
+
+    @Test
+    fun `nonexistent shop throws NoSuchElementException`() = runTest {
+        assertFailsWith<NoSuchElementException> {
+            useCase(999L, "Name", ShopType.Blacksmith)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements all CRUD and inventory management use cases for shops in the `:domain` module, as specified in issue #5.

## Changes
- **`:domain` module — use cases:**
  - `CreateShopUseCase` — creates a shop with name, type, optional description (validates non-blank name)
  - `UpdateShopUseCase` — updates shop name, type, description (validates non-blank name, checks shop exists)
  - `DeleteShopUseCase` — deletes a shop and its inventory
  - `GetAllShopsUseCase` — returns all shops as a reactive Flow
  - `GetShopWithInventoryUseCase` — returns a shop with its full inventory as a reactive Flow
  - `AddItemToShopUseCase` — adds a catalog or custom item to a shop's inventory
  - `RemoveItemFromShopUseCase` — removes an item from a shop's inventory
  - `DecrementQuantityUseCase` — decrements quantity by 1; null (unlimited) and 0 (sold out) are no-ops
  - `RegenerateInventoryUseCase` — clears inventory and delegates to `GenerateInventoryUseCase`
  - `GenerateInventoryUseCase` — interface for inventory generation (implementation provided by #4)
- **`:domain` module — test support:**
  - `FakeShopRepository` — in-memory test double for `ShopRepository`
  - `TestFixtures` — shared test factory methods

## Testing
- 9 test classes with 40+ test cases covering:
  - Happy paths for all use cases
  - Business rule enforcement (blank name validation, shop existence checks)
  - Edge cases: null quantity no-op, zero quantity no-op, whitespace trimming, empty description normalization
  - Multiple decrements, nonexistent entity handling
- All tests pass via `./gradlew :domain:jvmTest`

- [x] All tests pass (`./gradlew :domain:jvmTest`)
- [x] Domain module compiles successfully

Closes #5