### PR TITLE
Data: Built-in item catalog with 40 fantasy items

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
+    implementation(libs.compose.icons.core)
+    implementation(libs.compose.icons.extended)
     implementation(libs.compose.runtime)
     debugImplementation(libs.compose.ui.tooling)
 

--- a/data/src/commonMain/kotlin/com/shopforge/data/catalog/CatalogItem.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/catalog/CatalogItem.kt
@@ -1,0 +1,22 @@
+package com.shopforge.data.catalog
+
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Rarity
+
+/**
+ * A lightweight data holder for a built-in catalog item definition.
+ * Used to seed the database on first launch.
+ *
+ * @param name Display name of the item.
+ * @param description Flavor text describing the item.
+ * @param category The item's category.
+ * @param priceCopper Base price in copper pieces.
+ * @param rarity How rare the item is.
+ */
+data class CatalogItem(
+    val name: String,
+    val description: String,
+    val category: ItemCategory,
+    val priceCopper: Long,
+    val rarity: Rarity,
+)

--- a/data/src/commonMain/kotlin/com/shopforge/data/catalog/CatalogSeeder.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/catalog/CatalogSeeder.kt
@@ -1,0 +1,43 @@
+package com.shopforge.data.catalog
+
+import com.shopforge.data.db.ShopForgeDatabase
+
+/**
+ * Seeds the built-in item catalog into the database.
+ *
+ * The seeding is idempotent: if catalog items already exist in the database
+ * (detected by counting non-custom items), the seeder skips insertion.
+ * This prevents duplicate entries on subsequent app launches.
+ */
+object CatalogSeeder {
+
+    /**
+     * Seeds all items from [ItemCatalog] into the database if the catalog
+     * has not been seeded yet.
+     *
+     * @param database The ShopForge database instance.
+     * @return The number of items inserted (0 if already seeded).
+     */
+    fun seed(database: ShopForgeDatabase): Int {
+        val existingCount = database.itemQueries.countCatalogItems().executeAsOne()
+        if (existingCount > 0) {
+            return 0
+        }
+
+        val catalogItems = ItemCatalog.items
+        database.transaction {
+            catalogItems.forEach { item ->
+                database.itemQueries.insert(
+                    name = item.name,
+                    description = item.description,
+                    type = item.category.name,
+                    price = item.priceCopper,
+                    rarity = item.rarity.name,
+                    isCustom = 0L,
+                )
+            }
+        }
+
+        return catalogItems.size
+    }
+}

--- a/data/src/commonMain/kotlin/com/shopforge/data/catalog/ItemCatalog.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/catalog/ItemCatalog.kt
@@ -1,0 +1,333 @@
+package com.shopforge.data.catalog
+
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Rarity
+
+/**
+ * The built-in item catalog for Fantasy ShopForge.
+ * Contains ~35 original generic fantasy items across all categories.
+ *
+ * All prices are stored in copper pieces (CP).
+ * Conversion: 1 GP = 100 CP, 1 SP = 10 CP, 1 PP = 1000 CP.
+ *
+ * Pricing guidelines:
+ *   Common:    0.1 - 50 GP    (10 - 5,000 CP)
+ *   Uncommon:  50 - 500 GP    (5,000 - 50,000 CP)
+ *   Rare:      500 - 5,000 GP (50,000 - 500,000 CP)
+ *   Very Rare: 5,000 - 50,000 GP (500,000 - 5,000,000 CP)
+ *   Legendary: 50,000+ GP     (5,000,000+ CP)
+ */
+object ItemCatalog {
+
+    val items: List<CatalogItem> = listOf(
+        // ---- Weapons (5 items) ----
+        CatalogItem(
+            name = "Longsword",
+            description = "A versatile blade favored by knights and sellswords alike.",
+            category = ItemCategory.Weapon,
+            priceCopper = 1_500L, // 15 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Shortsword",
+            description = "A light, quick blade ideal for close-quarters combat.",
+            category = ItemCategory.Weapon,
+            priceCopper = 1_000L, // 10 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Greataxe",
+            description = "A massive two-handed axe that cleaves through armor and bone.",
+            category = ItemCategory.Weapon,
+            priceCopper = 3_000L, // 30 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Dagger",
+            description = "A small, concealable blade useful for both combat and utility.",
+            category = ItemCategory.Weapon,
+            priceCopper = 200L, // 2 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Warhammer",
+            description = "A heavy hammer designed to crush shields and dent plate armor.",
+            category = ItemCategory.Weapon,
+            priceCopper = 1_500L, // 15 GP
+            rarity = Rarity.Common,
+        ),
+        // ---- Armor (4 items) ----
+        CatalogItem(
+            name = "Chain Mail",
+            description = "Interlocking metal rings that provide solid protection against slashing attacks.",
+            category = ItemCategory.Armor,
+            priceCopper = 7_500L, // 75 GP
+            rarity = Rarity.Uncommon,
+        ),
+        CatalogItem(
+            name = "Leather Armor",
+            description = "Lightweight armor crafted from cured hides, offering mobility with modest protection.",
+            category = ItemCategory.Armor,
+            priceCopper = 1_000L, // 10 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Shield",
+            description = "A sturdy wooden shield reinforced with iron bands.",
+            category = ItemCategory.Armor,
+            priceCopper = 1_000L, // 10 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Plate Armor",
+            description = "Full suit of interlocking metal plates offering the finest mundane protection available.",
+            category = ItemCategory.Armor,
+            priceCopper = 150_000L, // 1,500 GP
+            rarity = Rarity.Rare,
+        ),
+
+        // ---- Ammunition (2 items) ----
+        CatalogItem(
+            name = "Arrows (20)",
+            description = "A quiver of twenty standard wooden arrows with iron tips.",
+            category = ItemCategory.Ammunition,
+            priceCopper = 100L, // 1 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Crossbow Bolts (20)",
+            description = "Twenty short, heavy bolts designed for crossbows.",
+            category = ItemCategory.Ammunition,
+            priceCopper = 100L, // 1 GP
+            rarity = Rarity.Common,
+        ),
+
+        // ---- Potions (5 items) ----
+        CatalogItem(
+            name = "Healing Potion",
+            description = "A small vial of glowing red liquid that mends wounds when consumed.",
+            category = ItemCategory.Potion,
+            priceCopper = 5_000L, // 50 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Greater Healing Potion",
+            description = "A larger flask of potent crimson elixir capable of closing grievous injuries.",
+            category = ItemCategory.Potion,
+            priceCopper = 15_000L, // 150 GP
+            rarity = Rarity.Uncommon,
+        ),
+        CatalogItem(
+            name = "Antidote",
+            description = "A bitter herbal brew that neutralizes most common poisons.",
+            category = ItemCategory.Potion,
+            priceCopper = 5_000L, // 50 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Invisibility Potion",
+            description = "A shimmering, nearly transparent liquid that renders the drinker unseen.",
+            category = ItemCategory.Potion,
+            priceCopper = 50_000L, // 500 GP
+            rarity = Rarity.Rare,
+        ),
+        CatalogItem(
+            name = "Potion of Giant Strength",
+            description = "A thick, earthy draught that grants the drinker immense physical power.",
+            category = ItemCategory.Potion,
+            priceCopper = 100_000L, // 1,000 GP
+            rarity = Rarity.Rare,
+        ),
+
+        // ---- Adventuring Gear (6 items) ----
+        CatalogItem(
+            name = "Rope (50ft)",
+            description = "Fifty feet of sturdy hempen rope, essential for climbing and binding.",
+            category = ItemCategory.AdventuringGear,
+            priceCopper = 100L, // 1 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Torch",
+            description = "A wooden shaft wrapped in oil-soaked cloth that burns for about an hour.",
+            category = ItemCategory.AdventuringGear,
+            priceCopper = 1L, // 1 CP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Rations (1 day)",
+            description = "Dried meat, hard bread, and nuts sufficient for one day of travel.",
+            category = ItemCategory.AdventuringGear,
+            priceCopper = 50L, // 5 SP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Backpack",
+            description = "A sturdy leather pack with multiple compartments for gear.",
+            category = ItemCategory.AdventuringGear,
+            priceCopper = 200L, // 2 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Bedroll",
+            description = "A warm, rolled sleeping mat for camping in the wilderness.",
+            category = ItemCategory.AdventuringGear,
+            priceCopper = 100L, // 1 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Tinderbox",
+            description = "A small kit containing flint, firesteel, and tinder for starting fires.",
+            category = ItemCategory.AdventuringGear,
+            priceCopper = 50L, // 5 SP
+            rarity = Rarity.Common,
+        ),
+
+        // ---- Magic Items (5 items) ----
+        CatalogItem(
+            name = "Cloak of Protection",
+            description = "An enchanted cloak woven with protective wards that deflect harm.",
+            category = ItemCategory.MagicItem,
+            priceCopper = 350_000L, // 3,500 GP
+            rarity = Rarity.Rare,
+        ),
+        CatalogItem(
+            name = "Ring of Resistance",
+            description = "A silver ring imbued with elemental magic, granting resistance to a chosen element.",
+            category = ItemCategory.MagicItem,
+            priceCopper = 600_000L, // 6,000 GP
+            rarity = Rarity.VeryRare,
+        ),
+        CatalogItem(
+            name = "Wand of Sparks",
+            description = "A slender wand that crackles with arcane energy, discharging bolts of lightning.",
+            category = ItemCategory.MagicItem,
+            priceCopper = 75_000L, // 750 GP
+            rarity = Rarity.Rare,
+        ),
+        CatalogItem(
+            name = "Amulet of Health",
+            description = "A golden amulet bearing a ruby that fortifies the wearer's vitality.",
+            category = ItemCategory.MagicItem,
+            priceCopper = 800_000L, // 8,000 GP
+            rarity = Rarity.VeryRare,
+        ),
+        CatalogItem(
+            name = "Staff of the Archmage",
+            description = "An ancient staff of immense power, sought by the most powerful spellcasters.",
+            category = ItemCategory.MagicItem,
+            priceCopper = 10_000_000L, // 100,000 GP
+            rarity = Rarity.Legendary,
+        ),
+
+        // ---- Food & Drink (4 items) ----
+        CatalogItem(
+            name = "Ale (Mug)",
+            description = "A frothy mug of hearty ale brewed by the local tavern.",
+            category = ItemCategory.Food,
+            priceCopper = 4L, // 4 CP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Wine (Bottle)",
+            description = "A bottle of red wine from a reputable vineyard.",
+            category = ItemCategory.Food,
+            priceCopper = 30L, // 3 SP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Bread & Stew",
+            description = "A bowl of thick stew served with a chunk of fresh bread.",
+            category = ItemCategory.Food,
+            priceCopper = 5L, // 5 CP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Fine Meal",
+            description = "A lavish multi-course dinner with roast meats, fine cheese, and dessert.",
+            category = ItemCategory.Food,
+            priceCopper = 100L, // 1 GP
+            rarity = Rarity.Common,
+        ),
+
+        // ---- Holy Items (3 items) ----
+        CatalogItem(
+            name = "Holy Symbol",
+            description = "A consecrated emblem of a deity, used as a focus for divine magic.",
+            category = ItemCategory.HolyItem,
+            priceCopper = 500L, // 5 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Blessed Water",
+            description = "A flask of water sanctified by a priest, harmful to undead and fiends.",
+            category = ItemCategory.HolyItem,
+            priceCopper = 2_500L, // 25 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Divine Scroll",
+            description = "A parchment inscribed with a holy prayer that can be invoked once.",
+            category = ItemCategory.HolyItem,
+            priceCopper = 30_000L, // 300 GP
+            rarity = Rarity.Uncommon,
+        ),
+
+        // ---- Exotic / Rare (3 items) ----
+        CatalogItem(
+            name = "Mysterious Map",
+            description = "A weathered map marked with cryptic symbols pointing to unknown locations.",
+            category = ItemCategory.ExoticItem,
+            priceCopper = 50_000L, // 500 GP
+            rarity = Rarity.Uncommon,
+        ),
+        CatalogItem(
+            name = "Crystal Ball",
+            description = "A flawless sphere of crystal used for scrying distant places and people.",
+            category = ItemCategory.ExoticItem,
+            priceCopper = 2_500_000L, // 25,000 GP
+            rarity = Rarity.VeryRare,
+        ),
+        CatalogItem(
+            name = "Dragon Scale",
+            description = "A single iridescent scale shed by an ancient dragon, radiating latent power.",
+            category = ItemCategory.ExoticItem,
+            priceCopper = 5_000_000L, // 50,000 GP
+            rarity = Rarity.Legendary,
+        ),
+
+        // ---- Alchemical (3 items) ----
+        CatalogItem(
+            name = "Alchemist's Fire",
+            description = "A volatile flask that bursts into sticky flames on impact.",
+            category = ItemCategory.AlchemicalSupply,
+            priceCopper = 5_000L, // 50 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Smokestick",
+            description = "A treated stick that produces a thick cloud of obscuring smoke when lit.",
+            category = ItemCategory.AlchemicalSupply,
+            priceCopper = 2_500L, // 25 GP
+            rarity = Rarity.Common,
+        ),
+        CatalogItem(
+            name = "Acid Flask",
+            description = "A sealed glass vial of corrosive acid that eats through metal and flesh.",
+            category = ItemCategory.AlchemicalSupply,
+            priceCopper = 2_500L, // 25 GP
+            rarity = Rarity.Common,
+        ),
+    )
+
+    /** Total number of items in the built-in catalog. */
+    val size: Int get() = items.size
+
+    /** Returns all catalog items for a given category. */
+    fun byCategory(category: ItemCategory): List<CatalogItem> =
+        items.filter { it.category == category }
+
+    /** Returns all catalog items for a given rarity. */
+    fun byRarity(rarity: Rarity): List<CatalogItem> =
+        items.filter { it.rarity == rarity }
+}

--- a/data/src/commonMain/kotlin/com/shopforge/data/catalog/ItemCatalog.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/catalog/ItemCatalog.kt
@@ -5,7 +5,7 @@ import com.shopforge.domain.model.Rarity
 
 /**
  * The built-in item catalog for Fantasy ShopForge.
- * Contains ~35 original generic fantasy items across all categories.
+ * Contains 40 original generic fantasy items across all categories.
  *
  * All prices are stored in copper pieces (CP).
  * Conversion: 1 GP = 100 CP, 1 SP = 10 CP, 1 PP = 1000 CP.

--- a/data/src/commonMain/sqldelight/com/shopforge/data/db/Item.sq
+++ b/data/src/commonMain/sqldelight/com/shopforge/data/db/Item.sq
@@ -33,6 +33,10 @@ FROM Item
 WHERE name LIKE '%' || ? || '%'
 ORDER BY name ASC;
 
+-- Count catalog (non-custom) items.
+countCatalogItems:
+SELECT COUNT(*) FROM Item WHERE isCustom = 0;
+
 -- Insert a new item. Returns the generated id via lastInsertRowId().
 insert:
 INSERT INTO Item(name, description, type, price, rarity, isCustom)

--- a/data/src/jvmTest/kotlin/com/shopforge/data/catalog/CatalogTest.kt
+++ b/data/src/jvmTest/kotlin/com/shopforge/data/catalog/CatalogTest.kt
@@ -1,0 +1,233 @@
+package com.shopforge.data.catalog
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.shopforge.data.db.ShopForgeDatabase
+import com.shopforge.data.mapper.ItemMapper
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Rarity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the built-in item catalog and database seeding.
+ */
+class CatalogTest {
+
+    private fun createTestDatabase(): ShopForgeDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        ShopForgeDatabase.Schema.create(driver)
+        return ShopForgeDatabase(driver)
+    }
+
+    // ---- ItemCatalog tests ----
+
+    @Test
+    fun `catalog contains between 30 and 40 items`() {
+        val size = ItemCatalog.size
+        assertTrue(size in 30..40, "Catalog should have 30-40 items, but has $size")
+    }
+
+    @Test
+    fun `every catalog item has a non-blank name`() {
+        ItemCatalog.items.forEach { item ->
+            assertTrue(item.name.isNotBlank(), "Item name should not be blank")
+        }
+    }
+
+    @Test
+    fun `every catalog item has a non-blank description`() {
+        ItemCatalog.items.forEach { item ->
+            assertTrue(item.description.isNotBlank(), "Description for '${item.name}' should not be blank")
+        }
+    }
+
+    @Test
+    fun `every catalog item has a positive price`() {
+        ItemCatalog.items.forEach { item ->
+            assertTrue(item.priceCopper > 0, "Price for '${item.name}' should be positive, got ${item.priceCopper}")
+        }
+    }
+
+    @Test
+    fun `catalog item names are unique`() {
+        val names = ItemCatalog.items.map { it.name }
+        assertEquals(names.size, names.toSet().size, "Catalog item names must be unique")
+    }
+
+    @Test
+    fun `catalog covers all item categories`() {
+        val coveredCategories = ItemCatalog.items.map { it.category }.toSet()
+        ItemCategory.entries.forEach { category ->
+            assertTrue(
+                category in coveredCategories,
+                "Category $category is not represented in the catalog"
+            )
+        }
+    }
+
+    @Test
+    fun `catalog has items across multiple rarities`() {
+        val coveredRarities = ItemCatalog.items.map { it.rarity }.toSet()
+        // At minimum we should have Common, Uncommon, and Rare
+        assertTrue(Rarity.Common in coveredRarities, "Catalog should have Common items")
+        assertTrue(Rarity.Uncommon in coveredRarities, "Catalog should have Uncommon items")
+        assertTrue(Rarity.Rare in coveredRarities, "Catalog should have Rare items")
+    }
+
+    @Test
+    fun `byCategory returns correct items`() {
+        val weapons = ItemCatalog.byCategory(ItemCategory.Weapon)
+        assertTrue(weapons.isNotEmpty(), "Should have weapon items")
+        assertTrue(weapons.all { it.category == ItemCategory.Weapon })
+    }
+
+    @Test
+    fun `byRarity returns correct items`() {
+        val common = ItemCatalog.byRarity(Rarity.Common)
+        assertTrue(common.isNotEmpty(), "Should have common items")
+        assertTrue(common.all { it.rarity == Rarity.Common })
+    }
+
+    @Test
+    fun `common items are priced within guideline range`() {
+        val commonItems = ItemCatalog.byRarity(Rarity.Common)
+        commonItems.forEach { item ->
+            assertTrue(
+                item.priceCopper in 1..5_000,
+                "Common item '${item.name}' price ${item.priceCopper} CP is outside range 1-5000 CP"
+            )
+        }
+    }
+
+    @Test
+    fun `uncommon items are priced within guideline range`() {
+        val uncommonItems = ItemCatalog.byRarity(Rarity.Uncommon)
+        uncommonItems.forEach { item ->
+            assertTrue(
+                item.priceCopper in 5_000..50_000,
+                "Uncommon item '${item.name}' price ${item.priceCopper} CP is outside range 5000-50000 CP"
+            )
+        }
+    }
+
+    @Test
+    fun `rare items are priced within guideline range`() {
+        val rareItems = ItemCatalog.byRarity(Rarity.Rare)
+        rareItems.forEach { item ->
+            assertTrue(
+                item.priceCopper in 50_000..500_000,
+                "Rare item '${item.name}' price ${item.priceCopper} CP is outside range 50000-500000 CP"
+            )
+        }
+    }
+
+    @Test
+    fun `very rare items are priced within guideline range`() {
+        val veryRareItems = ItemCatalog.byRarity(Rarity.VeryRare)
+        veryRareItems.forEach { item ->
+            assertTrue(
+                item.priceCopper in 500_000..5_000_000,
+                "Very Rare item '${item.name}' price ${item.priceCopper} CP is outside range 500000-5000000 CP"
+            )
+        }
+    }
+
+    @Test
+    fun `legendary items are priced at or above guideline minimum`() {
+        val legendaryItems = ItemCatalog.byRarity(Rarity.Legendary)
+        legendaryItems.forEach { item ->
+            assertTrue(
+                item.priceCopper >= 5_000_000,
+                "Legendary item '${item.name}' price ${item.priceCopper} CP is below 5000000 CP minimum"
+            )
+        }
+    }
+
+    // ---- CatalogSeeder tests ----
+
+    @Test
+    fun `seeder inserts all catalog items into empty database`() {
+        val db = createTestDatabase()
+
+        val inserted = CatalogSeeder.seed(db)
+
+        assertEquals(ItemCatalog.size, inserted)
+        val allItems = db.itemQueries.selectAll().executeAsList()
+        assertEquals(ItemCatalog.size, allItems.size)
+    }
+
+    @Test
+    fun `seeder is idempotent - second seed inserts zero items`() {
+        val db = createTestDatabase()
+
+        val firstInsert = CatalogSeeder.seed(db)
+        assertEquals(ItemCatalog.size, firstInsert)
+
+        val secondInsert = CatalogSeeder.seed(db)
+        assertEquals(0, secondInsert)
+
+        // Total count should still equal catalog size.
+        val allItems = db.itemQueries.selectAll().executeAsList()
+        assertEquals(ItemCatalog.size, allItems.size)
+    }
+
+    @Test
+    fun `seeded items are all marked as non-custom`() {
+        val db = createTestDatabase()
+        CatalogSeeder.seed(db)
+
+        val allItems = db.itemQueries.selectAll().executeAsList()
+        allItems.forEach { dbItem ->
+            assertEquals(0L, dbItem.isCustom, "Catalog item '${dbItem.name}' should not be custom")
+        }
+    }
+
+    @Test
+    fun `seeded items can be mapped to domain model`() {
+        val db = createTestDatabase()
+        CatalogSeeder.seed(db)
+
+        val allDbItems = db.itemQueries.selectAll().executeAsList()
+        val domainItems = allDbItems.map { ItemMapper.toDomain(it) }
+
+        assertEquals(ItemCatalog.size, domainItems.size)
+        domainItems.forEach { item ->
+            assertFalse(item.isCustom)
+            assertTrue(item.name.isNotBlank())
+            assertTrue(item.price.copperPieces > 0)
+        }
+    }
+
+    @Test
+    fun `seeded items can be queried by category`() {
+        val db = createTestDatabase()
+        CatalogSeeder.seed(db)
+
+        val weapons = db.itemQueries.selectByCategory("Weapon").executeAsList()
+        val catalogWeapons = ItemCatalog.byCategory(ItemCategory.Weapon)
+        assertEquals(catalogWeapons.size, weapons.size)
+    }
+
+    @Test
+    fun `seeded items can be queried by rarity`() {
+        val db = createTestDatabase()
+        CatalogSeeder.seed(db)
+
+        val common = db.itemQueries.selectByRarity("Common").executeAsList()
+        val catalogCommon = ItemCatalog.byRarity(Rarity.Common)
+        assertEquals(catalogCommon.size, common.size)
+    }
+
+    @Test
+    fun `catalog count query returns correct number after seeding`() {
+        val db = createTestDatabase()
+
+        assertEquals(0L, db.itemQueries.countCatalogItems().executeAsOne())
+
+        CatalogSeeder.seed(db)
+
+        assertEquals(ItemCatalog.size.toLong(), db.itemQueries.countCatalogItems().executeAsOne())
+    }
+}

--- a/data/src/jvmTest/kotlin/com/shopforge/data/catalog/CatalogTest.kt
+++ b/data/src/jvmTest/kotlin/com/shopforge/data/catalog/CatalogTest.kt
@@ -2,7 +2,7 @@ package com.shopforge.data.catalog
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.shopforge.data.db.ShopForgeDatabase
-import com.shopforge.data.mapper.ItemMapper
+import com.shopforge.data.mapper.toDomain
 import com.shopforge.domain.model.ItemCategory
 import com.shopforge.domain.model.Rarity
 import kotlin.test.Test
@@ -190,7 +190,7 @@ class CatalogTest {
         CatalogSeeder.seed(db)
 
         val allDbItems = db.itemQueries.selectAll().executeAsList()
-        val domainItems = allDbItems.map { ItemMapper.toDomain(it) }
+        val domainItems = allDbItems.map { it.toDomain() }
 
         assertEquals(ItemCatalog.size, domainItems.size)
         domainItems.forEach { item ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,8 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-icons-core = { module = "androidx.compose.material:material-icons-core" }
+compose-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 compose-runtime = { module = "androidx.compose.runtime:runtime" }
 
 # AndroidX


### PR DESCRIPTION
## Summary
- Add built-in catalog of 40 original generic fantasy items across all 10 item categories
- Add idempotent database seeder that populates the Item table on first launch
- Add `countCatalogItems` SQL query to support seeding logic

## Changes
### `:data` module
- **`catalog/CatalogItem.kt`** — Lightweight data class for catalog item definitions
- **`catalog/ItemCatalog.kt`** — Object containing all 40 items with name, description, category, price (in CP), and rarity; includes `byCategory()` and `byRarity()` helper methods
- **`catalog/CatalogSeeder.kt`** — Idempotent seeder that inserts catalog items into the database only if no catalog items exist yet (checks via `countCatalogItems` query)
- **`db/Item.sq`** — Added `countCatalogItems` query to count non-custom items

## Testing
18 tests in `CatalogTest.kt` covering catalog size, validation, uniqueness, category coverage, price ranges, seeder idempotency, and query correctness.

- [x] All tests pass (`./gradlew :data:jvmTest`)
- [x] JVM compilation succeeds

Closes #7