### PR TITLE
Data: Repository implementations

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
         jvmTest.dependencies {
             implementation(libs.sqldelight.sqlite.driver)
             implementation(libs.junit.jupiter)
+            implementation(libs.turbine)
         }
     }
 }

--- a/data/src/commonMain/kotlin/com/shopforge/data/repository/CatalogItems.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/repository/CatalogItems.kt
@@ -1,0 +1,75 @@
+package com.shopforge.data.repository
+
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.Rarity
+
+/**
+ * Built-in catalog of generic fantasy items shipped with the app.
+ * These are original items (no SRD/OGL content) covering all shop types.
+ *
+ * Prices are stored in copper pieces (CP). Conversion: 1 GP = 100 CP, 1 SP = 10 CP.
+ */
+internal object CatalogItems {
+
+    val all: List<Item> = listOf(
+        // ---- Weapons ----
+        Item(id = 0, name = "Longsword", description = "A versatile steel blade favored by knights", category = ItemCategory.Weapon, price = Price.ofGold(15), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Shortsword", description = "A light, quick blade for close combat", category = ItemCategory.Weapon, price = Price.ofGold(10), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Dagger", description = "A simple but reliable stabbing weapon", category = ItemCategory.Weapon, price = Price.ofGold(2), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Battleaxe", description = "A heavy axe built for war", category = ItemCategory.Weapon, price = Price.ofGold(10), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Warhammer", description = "A crushing weapon of forged iron", category = ItemCategory.Weapon, price = Price.ofGold(15), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Armor ----
+        Item(id = 0, name = "Chain Mail", description = "Interlocking metal rings offering solid protection", category = ItemCategory.Armor, price = Price.ofGold(75), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Leather Armor", description = "Cured hide shaped into a protective vest", category = ItemCategory.Armor, price = Price.ofGold(10), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Plate Armor", description = "Full suit of forged steel plates", category = ItemCategory.Armor, price = Price.ofGold(1500), rarity = Rarity.Uncommon, isCustom = false),
+        Item(id = 0, name = "Wooden Shield", description = "A sturdy round shield of oak", category = ItemCategory.Armor, price = Price.ofGold(5), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Potions ----
+        Item(id = 0, name = "Potion of Healing", description = "A crimson liquid that mends wounds", category = ItemCategory.Potion, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Potion of Greater Healing", description = "A potent restorative draught", category = ItemCategory.Potion, price = Price.ofGold(150), rarity = Rarity.Uncommon, isCustom = false),
+        Item(id = 0, name = "Potion of Fire Resistance", description = "Grants temporary resistance to flames", category = ItemCategory.Potion, price = Price.ofGold(300), rarity = Rarity.Rare, isCustom = false),
+        Item(id = 0, name = "Antitoxin Vial", description = "Neutralizes most common poisons", category = ItemCategory.Potion, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Adventuring Gear ----
+        Item(id = 0, name = "Hempen Rope (50 ft)", description = "Strong rope for climbing and binding", category = ItemCategory.AdventuringGear, price = Price.ofGold(1), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Torch", description = "A wooden stick wrapped in oil-soaked cloth", category = ItemCategory.AdventuringGear, price = Price.ofCopper(1), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Backpack", description = "A sturdy leather pack for carrying supplies", category = ItemCategory.AdventuringGear, price = Price.ofGold(2), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Bedroll", description = "A padded roll for camping in the wild", category = ItemCategory.AdventuringGear, price = Price.ofGold(1), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Tinderbox", description = "Flint, steel, and tinder for starting fires", category = ItemCategory.AdventuringGear, price = Price.ofSilver(5), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Magic Items ----
+        Item(id = 0, name = "Wand of Sparks", description = "A wand that produces small bolts of lightning", category = ItemCategory.MagicItem, price = Price.ofGold(500), rarity = Rarity.Uncommon, isCustom = false),
+        Item(id = 0, name = "Cloak of Shadows", description = "A dark cloak that bends light around the wearer", category = ItemCategory.MagicItem, price = Price.ofGold(5000), rarity = Rarity.Rare, isCustom = false),
+        Item(id = 0, name = "Ring of Protection", description = "A silver ring that wards against harm", category = ItemCategory.MagicItem, price = Price.ofGold(3500), rarity = Rarity.Rare, isCustom = false),
+        Item(id = 0, name = "Amulet of Vitality", description = "A golden amulet that bolsters the wearer's endurance", category = ItemCategory.MagicItem, price = Price.ofGold(15000), rarity = Rarity.VeryRare, isCustom = false),
+
+        // ---- Food ----
+        Item(id = 0, name = "Rations (1 day)", description = "Dried meat, hardtack, and dried fruit", category = ItemCategory.Food, price = Price.ofSilver(5), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Ale (Mug)", description = "A frothy mug of hearty ale", category = ItemCategory.Food, price = Price.ofCopper(4), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Fine Wine (Bottle)", description = "An aged vintage from distant vineyards", category = ItemCategory.Food, price = Price.ofGold(10), rarity = Rarity.Uncommon, isCustom = false),
+        Item(id = 0, name = "Traveler's Stew", description = "A warm bowl of hearty stew", category = ItemCategory.Food, price = Price.ofSilver(3), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Holy Items ----
+        Item(id = 0, name = "Holy Symbol", description = "A sacred emblem of divine faith", category = ItemCategory.HolyItem, price = Price.ofGold(5), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Scroll of Blessing", description = "A parchment inscribed with a divine prayer", category = ItemCategory.HolyItem, price = Price.ofGold(100), rarity = Rarity.Uncommon, isCustom = false),
+        Item(id = 0, name = "Vial of Holy Water", description = "Water blessed by a high priest", category = ItemCategory.HolyItem, price = Price.ofGold(25), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Exotic Items ----
+        Item(id = 0, name = "Crystal Ball", description = "A smooth orb of polished quartz for scrying", category = ItemCategory.ExoticItem, price = Price.ofGold(10000), rarity = Rarity.VeryRare, isCustom = false),
+        Item(id = 0, name = "Dragon Scale", description = "A single iridescent scale from a true dragon", category = ItemCategory.ExoticItem, price = Price.ofGold(25000), rarity = Rarity.Legendary, isCustom = false),
+        Item(id = 0, name = "Mysterious Trinket", description = "A curious object that hums faintly with magic", category = ItemCategory.ExoticItem, price = Price.ofGold(250), rarity = Rarity.Uncommon, isCustom = false),
+
+        // ---- Ammunition ----
+        Item(id = 0, name = "Arrows (20)", description = "A bundle of wooden-shafted arrows", category = ItemCategory.Ammunition, price = Price.ofGold(1), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Crossbow Bolts (20)", description = "Short iron-tipped bolts for crossbows", category = ItemCategory.Ammunition, price = Price.ofGold(1), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Longbow", description = "A tall bow of yew for ranged combat", category = ItemCategory.Weapon, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),
+
+        // ---- Alchemical Supplies ----
+        Item(id = 0, name = "Alchemist's Fire", description = "A volatile flask that bursts into flame on impact", category = ItemCategory.AlchemicalSupply, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Smokestick", description = "A stick that emits thick concealing smoke", category = ItemCategory.AlchemicalSupply, price = Price.ofGold(25), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Thunderstone", description = "A small stone that creates a deafening bang", category = ItemCategory.AlchemicalSupply, price = Price.ofGold(30), rarity = Rarity.Uncommon, isCustom = false),
+    )
+}

--- a/data/src/commonMain/kotlin/com/shopforge/data/repository/CatalogItems.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/repository/CatalogItems.kt
@@ -20,6 +20,7 @@ internal object CatalogItems {
         Item(id = 0, name = "Dagger", description = "A simple but reliable stabbing weapon", category = ItemCategory.Weapon, price = Price.ofGold(2), rarity = Rarity.Common, isCustom = false),
         Item(id = 0, name = "Battleaxe", description = "A heavy axe built for war", category = ItemCategory.Weapon, price = Price.ofGold(10), rarity = Rarity.Common, isCustom = false),
         Item(id = 0, name = "Warhammer", description = "A crushing weapon of forged iron", category = ItemCategory.Weapon, price = Price.ofGold(15), rarity = Rarity.Common, isCustom = false),
+        Item(id = 0, name = "Longbow", description = "A tall bow of yew for ranged combat", category = ItemCategory.Weapon, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),
 
         // ---- Armor ----
         Item(id = 0, name = "Chain Mail", description = "Interlocking metal rings offering solid protection", category = ItemCategory.Armor, price = Price.ofGold(75), rarity = Rarity.Common, isCustom = false),
@@ -65,7 +66,6 @@ internal object CatalogItems {
         // ---- Ammunition ----
         Item(id = 0, name = "Arrows (20)", description = "A bundle of wooden-shafted arrows", category = ItemCategory.Ammunition, price = Price.ofGold(1), rarity = Rarity.Common, isCustom = false),
         Item(id = 0, name = "Crossbow Bolts (20)", description = "Short iron-tipped bolts for crossbows", category = ItemCategory.Ammunition, price = Price.ofGold(1), rarity = Rarity.Common, isCustom = false),
-        Item(id = 0, name = "Longbow", description = "A tall bow of yew for ranged combat", category = ItemCategory.Weapon, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),
 
         // ---- Alchemical Supplies ----
         Item(id = 0, name = "Alchemist's Fire", description = "A volatile flask that bursts into flame on impact", category = ItemCategory.AlchemicalSupply, price = Price.ofGold(50), rarity = Rarity.Common, isCustom = false),

--- a/data/src/commonMain/kotlin/com/shopforge/data/repository/ItemRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/repository/ItemRepositoryImpl.kt
@@ -1,0 +1,112 @@
+package com.shopforge.data.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.shopforge.data.db.ShopForgeDatabase
+import com.shopforge.data.mapper.ItemMapper
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Rarity
+import com.shopforge.domain.repository.ItemRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * SQLDelight-backed implementation of [ItemRepository].
+ *
+ * @param database The SQLDelight-generated database instance.
+ * @param context The coroutine context used for Flow emissions (defaults to [Dispatchers.Default]).
+ */
+class ItemRepositoryImpl(
+    private val database: ShopForgeDatabase,
+    private val context: CoroutineContext = Dispatchers.Default,
+) : ItemRepository {
+
+    private val itemQueries get() = database.itemQueries
+
+    // ---- Catalog queries ----
+
+    override fun getAllItems(): Flow<List<Item>> =
+        itemQueries.selectAll()
+            .asFlow()
+            .mapToList(context)
+            .map { list -> list.map(ItemMapper::toDomain) }
+
+    override suspend fun getItemsByCategory(category: ItemCategory): List<Item> =
+        itemQueries.selectByCategory(ItemMapper.toDbCategory(category))
+            .executeAsList()
+            .map(ItemMapper::toDomain)
+
+    override suspend fun getItemsByRarity(rarity: Rarity): List<Item> =
+        itemQueries.selectByRarity(ItemMapper.toDbRarity(rarity))
+            .executeAsList()
+            .map(ItemMapper::toDomain)
+
+    override suspend fun searchItems(query: String): List<Item> =
+        itemQueries.searchByName(query)
+            .executeAsList()
+            .map(ItemMapper::toDomain)
+
+    override suspend fun getItemById(id: Long): Item? =
+        itemQueries.selectById(id)
+            .executeAsOneOrNull()
+            ?.let(ItemMapper::toDomain)
+
+    // ---- Custom item CRUD ----
+
+    override suspend fun createCustomItem(item: Item): Long {
+        require(item.isCustom) { "Only custom items can be created via createCustomItem" }
+        itemQueries.insert(
+            name = item.name,
+            description = item.description,
+            type = ItemMapper.toDbCategory(item.category),
+            price = item.price.copperPieces,
+            rarity = ItemMapper.toDbRarity(item.rarity),
+            isCustom = ItemMapper.toDbIsCustom(true),
+        )
+        // Return the id of the last inserted row.
+        return itemQueries.selectAll().executeAsList().last { it.name == item.name }.id
+    }
+
+    override suspend fun updateCustomItem(item: Item) {
+        require(item.isCustom) { "Only custom items can be updated via updateCustomItem" }
+        itemQueries.update(
+            name = item.name,
+            description = item.description,
+            type = ItemMapper.toDbCategory(item.category),
+            price = item.price.copperPieces,
+            rarity = ItemMapper.toDbRarity(item.rarity),
+            id = item.id,
+        )
+    }
+
+    override suspend fun deleteCustomItem(id: Long) {
+        itemQueries.deleteCustom(id)
+    }
+
+    // ---- Catalog seeding ----
+
+    /**
+     * Seeds the catalog with built-in items if the database is empty.
+     * This operation is idempotent — if items already exist, nothing happens.
+     */
+    fun seedCatalogIfEmpty() {
+        val count = itemQueries.countAll().executeAsOne()
+        if (count > 0L) return
+
+        database.transaction {
+            CatalogItems.all.forEach { item ->
+                itemQueries.insert(
+                    name = item.name,
+                    description = item.description,
+                    type = ItemMapper.toDbCategory(item.category),
+                    price = item.price.copperPieces,
+                    rarity = ItemMapper.toDbRarity(item.rarity),
+                    isCustom = ItemMapper.toDbIsCustom(false),
+                )
+            }
+        }
+    }
+}

--- a/data/src/commonMain/kotlin/com/shopforge/data/repository/ItemRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/repository/ItemRepositoryImpl.kt
@@ -3,7 +3,9 @@ package com.shopforge.data.repository
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import com.shopforge.data.db.ShopForgeDatabase
-import com.shopforge.data.mapper.ItemMapper
+import com.shopforge.data.mapper.toDbIsCustom
+import com.shopforge.data.mapper.toDbString
+import com.shopforge.data.mapper.toDomain
 import com.shopforge.domain.model.Item
 import com.shopforge.domain.model.ItemCategory
 import com.shopforge.domain.model.Rarity
@@ -32,27 +34,27 @@ class ItemRepositoryImpl(
         itemQueries.selectAll()
             .asFlow()
             .mapToList(context)
-            .map { list -> list.map(ItemMapper::toDomain) }
+            .map { list -> list.map { it.toDomain() } }
 
     override suspend fun getItemsByCategory(category: ItemCategory): List<Item> =
-        itemQueries.selectByCategory(ItemMapper.toDbCategory(category))
+        itemQueries.selectByCategory(category.toDbString())
             .executeAsList()
-            .map(ItemMapper::toDomain)
+            .map { it.toDomain() }
 
     override suspend fun getItemsByRarity(rarity: Rarity): List<Item> =
-        itemQueries.selectByRarity(ItemMapper.toDbRarity(rarity))
+        itemQueries.selectByRarity(rarity.toDbString())
             .executeAsList()
-            .map(ItemMapper::toDomain)
+            .map { it.toDomain() }
 
     override suspend fun searchItems(query: String): List<Item> =
-        itemQueries.searchByName(query)
+        itemQueries.searchByName(query, query)
             .executeAsList()
-            .map(ItemMapper::toDomain)
+            .map { it.toDomain() }
 
     override suspend fun getItemById(id: Long): Item? =
         itemQueries.selectById(id)
             .executeAsOneOrNull()
-            ?.let(ItemMapper::toDomain)
+            ?.toDomain()
 
     // ---- Custom item CRUD ----
 
@@ -61,13 +63,12 @@ class ItemRepositoryImpl(
         itemQueries.insert(
             name = item.name,
             description = item.description,
-            type = ItemMapper.toDbCategory(item.category),
+            type = item.category.toDbString(),
             price = item.price.copperPieces,
-            rarity = ItemMapper.toDbRarity(item.rarity),
-            isCustom = ItemMapper.toDbIsCustom(true),
+            rarity = item.rarity.toDbString(),
+            isCustom = true.toDbIsCustom(),
         )
-        // Return the id of the last inserted row.
-        return itemQueries.selectAll().executeAsList().last { it.name == item.name }.id
+        return itemQueries.lastInsertRowId().executeAsOne()
     }
 
     override suspend fun updateCustomItem(item: Item) {
@@ -75,9 +76,9 @@ class ItemRepositoryImpl(
         itemQueries.update(
             name = item.name,
             description = item.description,
-            type = ItemMapper.toDbCategory(item.category),
+            type = item.category.toDbString(),
             price = item.price.copperPieces,
-            rarity = ItemMapper.toDbRarity(item.rarity),
+            rarity = item.rarity.toDbString(),
             id = item.id,
         )
     }
@@ -93,18 +94,18 @@ class ItemRepositoryImpl(
      * This operation is idempotent — if items already exist, nothing happens.
      */
     fun seedCatalogIfEmpty() {
-        val count = itemQueries.countAll().executeAsOne()
-        if (count > 0L) return
-
         database.transaction {
+            val count = itemQueries.countAll().executeAsOne()
+            if (count > 0L) return@transaction
+
             CatalogItems.all.forEach { item ->
                 itemQueries.insert(
                     name = item.name,
                     description = item.description,
-                    type = ItemMapper.toDbCategory(item.category),
+                    type = item.category.toDbString(),
                     price = item.price.copperPieces,
-                    rarity = ItemMapper.toDbRarity(item.rarity),
-                    isCustom = ItemMapper.toDbIsCustom(false),
+                    rarity = item.rarity.toDbString(),
+                    isCustom = false.toDbIsCustom(),
                 )
             }
         }

--- a/data/src/commonMain/kotlin/com/shopforge/data/repository/ShopRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/repository/ShopRepositoryImpl.kt
@@ -1,0 +1,124 @@
+package com.shopforge.data.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.shopforge.data.db.ShopForgeDatabase
+import com.shopforge.data.mapper.ShopInventoryMapper
+import com.shopforge.data.mapper.ShopMapper
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.Shop
+import com.shopforge.domain.model.ShopInventoryItem
+import com.shopforge.domain.repository.ShopRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * SQLDelight-backed implementation of [ShopRepository].
+ *
+ * @param database The SQLDelight-generated database instance.
+ * @param context The coroutine context used for Flow emissions (defaults to [Dispatchers.Default]).
+ */
+class ShopRepositoryImpl(
+    private val database: ShopForgeDatabase,
+    private val context: CoroutineContext = Dispatchers.Default,
+) : ShopRepository {
+
+    private val shopQueries get() = database.shopQueries
+    private val inventoryQueries get() = database.shopInventoryQueries
+
+    // ---- Shop CRUD ----
+
+    override fun getAllShops(): Flow<List<Shop>> =
+        shopQueries.selectAll()
+            .asFlow()
+            .mapToList(context)
+            .map { list -> list.map(ShopMapper::toDomain) }
+
+    override fun getShopById(id: Long): Flow<Shop?> =
+        shopQueries.selectById(id)
+            .asFlow()
+            .mapToOneOrNull(context)
+            .map { dbShop -> dbShop?.let(ShopMapper::toDomain) }
+
+    override suspend fun createShop(shop: Shop): Long {
+        shopQueries.insert(
+            name = shop.name,
+            type = ShopMapper.toDbType(shop.type),
+            description = shop.description,
+            createdAt = shop.createdAt,
+            updatedAt = shop.updatedAt,
+        )
+        // SQLDelight's last_insert_rowid() gives us the generated id.
+        return shopQueries.selectAll().executeAsList().first { it.name == shop.name }.id
+    }
+
+    override suspend fun updateShop(shop: Shop) {
+        shopQueries.update(
+            name = shop.name,
+            type = ShopMapper.toDbType(shop.type),
+            description = shop.description,
+            updatedAt = shop.updatedAt,
+            id = shop.id,
+        )
+    }
+
+    override suspend fun deleteShop(id: Long) {
+        database.transaction {
+            // Foreign key cascade handles inventory deletion,
+            // but we explicitly enable PRAGMA foreign_keys at driver level.
+            shopQueries.delete(id)
+        }
+    }
+
+    // ---- Inventory management ----
+
+    override fun getInventory(shopId: Long): Flow<List<ShopInventoryItem>> =
+        inventoryQueries.selectByShopId(shopId)
+            .asFlow()
+            .mapToList(context)
+            .map { list -> list.map(ShopInventoryMapper::toDomain) }
+
+    override suspend fun addItemToShop(
+        shopId: Long,
+        item: Item,
+        quantity: Int?,
+        adjustedPrice: Price,
+    ) {
+        inventoryQueries.insertItem(
+            shopId = shopId,
+            itemId = item.id,
+            quantity = quantity?.toLong(),
+            adjustedPrice = adjustedPrice.copperPieces,
+        )
+    }
+
+    override suspend fun removeItemFromShop(shopId: Long, itemId: Long) {
+        inventoryQueries.removeItem(shopId = shopId, itemId = itemId)
+    }
+
+    override suspend fun updateItemQuantity(shopId: Long, itemId: Long, quantity: Int?) {
+        inventoryQueries.updateQuantity(
+            quantity = quantity?.toLong(),
+            shopId = shopId,
+            itemId = itemId,
+        )
+    }
+
+    override suspend fun replaceInventory(shopId: Long, items: List<ShopInventoryItem>) {
+        database.transaction {
+            inventoryQueries.deleteByShopId(shopId)
+            items.forEach { inventoryItem ->
+                inventoryQueries.insertItem(
+                    shopId = shopId,
+                    itemId = inventoryItem.item.id,
+                    quantity = inventoryItem.quantity?.toLong(),
+                    adjustedPrice = inventoryItem.adjustedPrice.copperPieces,
+                )
+            }
+        }
+    }
+}

--- a/data/src/commonMain/kotlin/com/shopforge/data/repository/ShopRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/shopforge/data/repository/ShopRepositoryImpl.kt
@@ -4,8 +4,8 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.shopforge.data.db.ShopForgeDatabase
-import com.shopforge.data.mapper.ShopInventoryMapper
-import com.shopforge.data.mapper.ShopMapper
+import com.shopforge.data.mapper.toDbString
+import com.shopforge.data.mapper.toDomain
 import com.shopforge.domain.model.Item
 import com.shopforge.domain.model.Price
 import com.shopforge.domain.model.Shop
@@ -36,30 +36,29 @@ class ShopRepositoryImpl(
         shopQueries.selectAll()
             .asFlow()
             .mapToList(context)
-            .map { list -> list.map(ShopMapper::toDomain) }
+            .map { list -> list.map { it.toDomain() } }
 
     override fun getShopById(id: Long): Flow<Shop?> =
         shopQueries.selectById(id)
             .asFlow()
             .mapToOneOrNull(context)
-            .map { dbShop -> dbShop?.let(ShopMapper::toDomain) }
+            .map { dbShop -> dbShop?.toDomain() }
 
     override suspend fun createShop(shop: Shop): Long {
         shopQueries.insert(
             name = shop.name,
-            type = ShopMapper.toDbType(shop.type),
+            type = shop.type.toDbString(),
             description = shop.description,
             createdAt = shop.createdAt,
             updatedAt = shop.updatedAt,
         )
-        // SQLDelight's last_insert_rowid() gives us the generated id.
-        return shopQueries.selectAll().executeAsList().first { it.name == shop.name }.id
+        return shopQueries.lastInsertRowId().executeAsOne()
     }
 
     override suspend fun updateShop(shop: Shop) {
         shopQueries.update(
             name = shop.name,
-            type = ShopMapper.toDbType(shop.type),
+            type = shop.type.toDbString(),
             description = shop.description,
             updatedAt = shop.updatedAt,
             id = shop.id,
@@ -80,7 +79,7 @@ class ShopRepositoryImpl(
         inventoryQueries.selectByShopId(shopId)
             .asFlow()
             .mapToList(context)
-            .map { list -> list.map(ShopInventoryMapper::toDomain) }
+            .map { list -> list.map { it.toDomain() } }
 
     override suspend fun addItemToShop(
         shopId: Long,

--- a/data/src/commonMain/sqldelight/com/shopforge/data/db/Item.sq
+++ b/data/src/commonMain/sqldelight/com/shopforge/data/db/Item.sq
@@ -26,11 +26,11 @@ FROM Item
 WHERE rarity = ?
 ORDER BY name ASC;
 
--- Search items by name (case-insensitive).
+-- Search items by name or description (case-insensitive).
 searchByName:
 SELECT *
 FROM Item
-WHERE name LIKE '%' || ? || '%'
+WHERE name LIKE '%' || ? || '%' OR description LIKE '%' || ? || '%'
 ORDER BY name ASC;
 
 -- Count catalog (non-custom) items.
@@ -61,3 +61,7 @@ WHERE id = ? AND isCustom = 1;
 -- Count all items (used for catalog seeding check).
 countAll:
 SELECT COUNT(*) FROM Item;
+
+-- Return the row id of the last inserted row.
+lastInsertRowId:
+SELECT last_insert_rowid();

--- a/data/src/commonMain/sqldelight/com/shopforge/data/db/Item.sq
+++ b/data/src/commonMain/sqldelight/com/shopforge/data/db/Item.sq
@@ -46,9 +46,18 @@ VALUES (?, ?, ?, ?, ?, ?);
 update:
 UPDATE Item
 SET name = ?, description = ?, type = ?, price = ?, rarity = ?
-WHERE id = ?;
+WHERE id = ? AND isCustom = 1;
 
 -- Delete an item by id.
 delete:
 DELETE FROM Item
 WHERE id = ?;
+
+-- Delete a custom item by id. Only deletes if the item is custom.
+deleteCustom:
+DELETE FROM Item
+WHERE id = ? AND isCustom = 1;
+
+-- Count all items (used for catalog seeding check).
+countAll:
+SELECT COUNT(*) FROM Item;

--- a/data/src/commonMain/sqldelight/com/shopforge/data/db/Shop.sq
+++ b/data/src/commonMain/sqldelight/com/shopforge/data/db/Shop.sq
@@ -27,3 +27,7 @@ WHERE id = ?;
 delete:
 DELETE FROM Shop
 WHERE id = ?;
+
+-- Return the row id of the last inserted row.
+lastInsertRowId:
+SELECT last_insert_rowid();

--- a/data/src/jvmTest/kotlin/com/shopforge/data/SchemaTest.kt
+++ b/data/src/jvmTest/kotlin/com/shopforge/data/SchemaTest.kt
@@ -159,7 +159,7 @@ class SchemaTest {
         db.itemQueries.insert("Shortsword", null, "Weapon", 1000L, "Common", 0L)
         db.itemQueries.insert("Chain Mail", null, "Armor", 7500L, "Common", 0L)
 
-        val results = db.itemQueries.searchByName("sword").executeAsList()
+        val results = db.itemQueries.searchByName("sword", "sword").executeAsList()
         assertEquals(2, results.size)
         assertTrue(results.all { it.name.contains("sword", ignoreCase = true) })
     }
@@ -167,7 +167,7 @@ class SchemaTest {
     @Test
     fun `update item`() {
         val db = createTestDatabase()
-        db.itemQueries.insert("Longsword", "A standard longsword", "Weapon", 1500L, "Common", 0L)
+        db.itemQueries.insert("Longsword", "A standard longsword", "Weapon", 1500L, "Common", 1L)
         val id = db.itemQueries.selectAll().executeAsList().first().id
 
         db.itemQueries.update(
@@ -184,7 +184,7 @@ class SchemaTest {
         assertEquals("An upgraded blade", updated.description)
         assertEquals(5000L, updated.price)
         assertEquals("Rare", updated.rarity)
-        assertEquals(0L, updated.isCustom) // isCustom should not change
+        assertEquals(1L, updated.isCustom) // isCustom should not change
     }
 
     @Test

--- a/data/src/jvmTest/kotlin/com/shopforge/data/repository/ItemRepositoryImplTest.kt
+++ b/data/src/jvmTest/kotlin/com/shopforge/data/repository/ItemRepositoryImplTest.kt
@@ -1,0 +1,243 @@
+package com.shopforge.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.turbine.test
+import com.shopforge.data.db.ShopForgeDatabase
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.Rarity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [ItemRepositoryImpl] using an in-memory SQLite driver.
+ */
+class ItemRepositoryImplTest {
+
+    private fun createTestDatabase(): ShopForgeDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        ShopForgeDatabase.Schema.create(driver)
+        driver.execute(null, "PRAGMA foreign_keys = ON;", 0)
+        return ShopForgeDatabase(driver)
+    }
+
+    private fun createRepository(db: ShopForgeDatabase) =
+        ItemRepositoryImpl(db, Dispatchers.Unconfined)
+
+    private fun customItem(
+        name: String = "Custom Blade",
+        category: ItemCategory = ItemCategory.Weapon,
+        price: Price = Price.ofGold(100),
+        rarity: Rarity = Rarity.Rare,
+    ) = Item(
+        id = 0,
+        name = name,
+        description = "A custom creation",
+        category = category,
+        price = price,
+        rarity = rarity,
+        isCustom = true,
+    )
+
+    // ---- Catalog queries ----
+
+    @Test
+    fun `getAllItems emits items reactively`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.getAllItems().test {
+            // Initially empty.
+            assertEquals(0, awaitItem().size)
+
+            repo.createCustomItem(customItem())
+
+            // Should emit updated list.
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertEquals("Custom Blade", items.first().name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `getItemsByCategory returns only matching items`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.createCustomItem(customItem(name = "Sword", category = ItemCategory.Weapon))
+        repo.createCustomItem(customItem(name = "Shield", category = ItemCategory.Armor))
+
+        val weapons = repo.getItemsByCategory(ItemCategory.Weapon)
+        assertEquals(1, weapons.size)
+        assertEquals("Sword", weapons.first().name)
+    }
+
+    @Test
+    fun `getItemsByRarity returns only matching items`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.createCustomItem(customItem(name = "Common Sword", rarity = Rarity.Common))
+        repo.createCustomItem(customItem(name = "Rare Blade", rarity = Rarity.Rare))
+
+        val rareItems = repo.getItemsByRarity(Rarity.Rare)
+        assertEquals(1, rareItems.size)
+        assertEquals("Rare Blade", rareItems.first().name)
+    }
+
+    @Test
+    fun `searchItems returns items matching query case-insensitively`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.createCustomItem(customItem(name = "Flame Sword"))
+        repo.createCustomItem(customItem(name = "Ice Shield"))
+
+        val results = repo.searchItems("sword")
+        assertEquals(1, results.size)
+        assertEquals("Flame Sword", results.first().name)
+    }
+
+    @Test
+    fun `searchItems returns empty list for no matches`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.createCustomItem(customItem(name = "Flame Sword"))
+
+        val results = repo.searchItems("potion")
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun `getItemById returns item when it exists`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createCustomItem(customItem())
+        val item = repo.getItemById(id)
+
+        assertNotNull(item)
+        assertEquals("Custom Blade", item.name)
+    }
+
+    @Test
+    fun `getItemById returns null for nonexistent id`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        assertNull(repo.getItemById(999L))
+    }
+
+    // ---- Custom item CRUD ----
+
+    @Test
+    fun `createCustomItem inserts item and returns generated id`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createCustomItem(customItem())
+        assertTrue(id > 0)
+
+        val item = repo.getItemById(id)
+        assertNotNull(item)
+        assertTrue(item.isCustom)
+    }
+
+    @Test
+    fun `updateCustomItem modifies existing custom item`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createCustomItem(customItem())
+        val updated = customItem(name = "Updated Blade").copy(id = id)
+        repo.updateCustomItem(updated)
+
+        val item = repo.getItemById(id)
+        assertNotNull(item)
+        assertEquals("Updated Blade", item.name)
+    }
+
+    @Test
+    fun `deleteCustomItem removes the item`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createCustomItem(customItem())
+        repo.deleteCustomItem(id)
+
+        assertNull(repo.getItemById(id))
+    }
+
+    // ---- Catalog seeding ----
+
+    @Test
+    fun `seedCatalogIfEmpty inserts catalog items into empty database`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.seedCatalogIfEmpty()
+
+        repo.getAllItems().test {
+            val items = awaitItem()
+            assertEquals(CatalogItems.all.size, items.size)
+            // Verify items are not marked as custom.
+            assertTrue(items.none { it.isCustom })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `seedCatalogIfEmpty is idempotent`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.seedCatalogIfEmpty()
+        val countAfterFirst = db.itemQueries.countAll().executeAsOne()
+
+        repo.seedCatalogIfEmpty()
+        val countAfterSecond = db.itemQueries.countAll().executeAsOne()
+
+        assertEquals(countAfterFirst, countAfterSecond)
+    }
+
+    @Test
+    fun `seedCatalogIfEmpty does not overwrite existing items`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        // Add a custom item first.
+        repo.createCustomItem(customItem())
+
+        // Seeding should be skipped since items already exist.
+        repo.seedCatalogIfEmpty()
+
+        repo.getAllItems().test {
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertTrue(items.first().isCustom)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `seeded catalog contains items from all categories`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.seedCatalogIfEmpty()
+
+        // Every ItemCategory should have at least one item in the catalog.
+        ItemCategory.entries.forEach { category ->
+            val items = repo.getItemsByCategory(category)
+            assertTrue(items.isNotEmpty(), "Expected at least one item in category $category")
+        }
+    }
+}

--- a/data/src/jvmTest/kotlin/com/shopforge/data/repository/ShopRepositoryImplTest.kt
+++ b/data/src/jvmTest/kotlin/com/shopforge/data/repository/ShopRepositoryImplTest.kt
@@ -1,0 +1,327 @@
+package com.shopforge.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.turbine.test
+import com.shopforge.data.db.ShopForgeDatabase
+import com.shopforge.domain.model.Item
+import com.shopforge.domain.model.ItemCategory
+import com.shopforge.domain.model.Price
+import com.shopforge.domain.model.Rarity
+import com.shopforge.domain.model.Shop
+import com.shopforge.domain.model.ShopInventoryItem
+import com.shopforge.domain.model.ShopType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [ShopRepositoryImpl] using an in-memory SQLite driver.
+ */
+class ShopRepositoryImplTest {
+
+    private fun createTestDatabase(): ShopForgeDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        ShopForgeDatabase.Schema.create(driver)
+        driver.execute(null, "PRAGMA foreign_keys = ON;", 0)
+        return ShopForgeDatabase(driver)
+    }
+
+    private fun createRepository(db: ShopForgeDatabase) =
+        ShopRepositoryImpl(db, Dispatchers.Unconfined)
+
+    private fun testShop(
+        name: String = "The Gilded Anvil",
+        type: ShopType = ShopType.Blacksmith,
+        description: String? = "A fine smithy",
+    ) = Shop(
+        id = 0,
+        name = name,
+        type = type,
+        description = description,
+        createdAt = 1000L,
+        updatedAt = 1000L,
+    )
+
+    private fun insertTestItem(db: ShopForgeDatabase, name: String = "Longsword", price: Long = 1500L): Long {
+        db.itemQueries.insert(name, "A blade", "Weapon", price, "Common", 0L)
+        return db.itemQueries.selectAll().executeAsList().first { it.name == name }.id
+    }
+
+    // ---- Shop CRUD ----
+
+    @Test
+    fun `createShop inserts shop and returns generated id`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createShop(testShop())
+        assertTrue(id > 0)
+    }
+
+    @Test
+    fun `getAllShops emits list of all shops`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.createShop(testShop(name = "Shop A"))
+        repo.createShop(testShop(name = "Shop B"))
+
+        repo.getAllShops().test {
+            val shops = awaitItem()
+            assertEquals(2, shops.size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `getAllShops emits reactively when shop is added`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.getAllShops().test {
+            // Initial emission: empty list.
+            assertEquals(0, awaitItem().size)
+
+            repo.createShop(testShop(name = "New Shop"))
+
+            // Second emission after insert.
+            val shops = awaitItem()
+            assertEquals(1, shops.size)
+            assertEquals("New Shop", shops.first().name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `getShopById returns shop when it exists`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createShop(testShop())
+
+        repo.getShopById(id).test {
+            val shop = awaitItem()
+            assertNotNull(shop)
+            assertEquals("The Gilded Anvil", shop.name)
+            assertEquals(ShopType.Blacksmith, shop.type)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `getShopById emits null for nonexistent id`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        repo.getShopById(999L).test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updateShop modifies existing shop`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createShop(testShop())
+
+        repo.updateShop(
+            Shop(
+                id = id,
+                name = "Updated Name",
+                type = ShopType.MagicShop,
+                description = "Updated desc",
+                createdAt = 1000L,
+                updatedAt = 2000L,
+            )
+        )
+
+        repo.getShopById(id).test {
+            val shop = awaitItem()
+            assertNotNull(shop)
+            assertEquals("Updated Name", shop.name)
+            assertEquals(ShopType.MagicShop, shop.type)
+            assertEquals("Updated desc", shop.description)
+            assertEquals(2000L, shop.updatedAt)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `deleteShop removes shop`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val id = repo.createShop(testShop())
+        repo.deleteShop(id)
+
+        repo.getShopById(id).test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ---- Inventory management ----
+
+    @Test
+    fun `addItemToShop and getInventory returns inventory items`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val shopId = repo.createShop(testShop())
+        val itemId = insertTestItem(db)
+
+        val item = Item(
+            id = itemId, name = "Longsword", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(15),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        repo.addItemToShop(shopId, item, quantity = 5, adjustedPrice = Price.ofGold(16))
+
+        repo.getInventory(shopId).test {
+            val inventory = awaitItem()
+            assertEquals(1, inventory.size)
+            assertEquals("Longsword", inventory.first().item.name)
+            assertEquals(5, inventory.first().quantity)
+            assertEquals(Price.ofGold(16), inventory.first().adjustedPrice)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addItemToShop with null quantity represents unlimited stock`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val shopId = repo.createShop(testShop())
+        val itemId = insertTestItem(db)
+
+        val item = Item(
+            id = itemId, name = "Longsword", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(15),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        repo.addItemToShop(shopId, item, quantity = null, adjustedPrice = Price.ofGold(15))
+
+        repo.getInventory(shopId).test {
+            val inventory = awaitItem()
+            assertTrue(inventory.first().isUnlimitedStock)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `removeItemFromShop removes item from inventory`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val shopId = repo.createShop(testShop())
+        val itemId = insertTestItem(db)
+
+        val item = Item(
+            id = itemId, name = "Longsword", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(15),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        repo.addItemToShop(shopId, item, quantity = 5, adjustedPrice = Price.ofGold(15))
+        repo.removeItemFromShop(shopId, itemId)
+
+        repo.getInventory(shopId).test {
+            assertEquals(0, awaitItem().size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updateItemQuantity changes quantity`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val shopId = repo.createShop(testShop())
+        val itemId = insertTestItem(db)
+
+        val item = Item(
+            id = itemId, name = "Longsword", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(15),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        repo.addItemToShop(shopId, item, quantity = 5, adjustedPrice = Price.ofGold(15))
+        repo.updateItemQuantity(shopId, itemId, quantity = 3)
+
+        repo.getInventory(shopId).test {
+            val inventory = awaitItem()
+            assertEquals(3, inventory.first().quantity)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `replaceInventory clears and replaces all items`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val shopId = repo.createShop(testShop())
+        val swordId = insertTestItem(db, "Longsword", 1500L)
+        val daggerId = insertTestItem(db, "Dagger", 200L)
+
+        val sword = Item(
+            id = swordId, name = "Longsword", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(15),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        repo.addItemToShop(shopId, sword, quantity = 5, adjustedPrice = Price.ofGold(15))
+
+        val dagger = Item(
+            id = daggerId, name = "Dagger", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(2),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        val newInventory = listOf(
+            ShopInventoryItem(item = dagger, quantity = 10, adjustedPrice = Price.ofGold(2)),
+        )
+        repo.replaceInventory(shopId, newInventory)
+
+        repo.getInventory(shopId).test {
+            val inventory = awaitItem()
+            assertEquals(1, inventory.size)
+            assertEquals("Dagger", inventory.first().item.name)
+            assertEquals(10, inventory.first().quantity)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cascade delete removes inventory when shop is deleted`() = runTest {
+        val db = createTestDatabase()
+        val repo = createRepository(db)
+
+        val shopId = repo.createShop(testShop())
+        val itemId = insertTestItem(db)
+
+        val item = Item(
+            id = itemId, name = "Longsword", description = "A blade",
+            category = ItemCategory.Weapon, price = Price.ofGold(15),
+            rarity = Rarity.Common, isCustom = false,
+        )
+        repo.addItemToShop(shopId, item, quantity = 5, adjustedPrice = Price.ofGold(15))
+
+        // Verify inventory exists before delete.
+        repo.getInventory(shopId).test {
+            assertEquals(1, awaitItem().size)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repo.deleteShop(shopId)
+
+        // Inventory should be empty after cascade delete.
+        repo.getInventory(shopId).test {
+            assertEquals(0, awaitItem().size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implement `ShopRepository` and `ItemRepository` interfaces from `:domain` using SQLDelight in the `:data` module. Includes a built-in catalog of ~38 original fantasy items and idempotent catalog seeding.

## Changes
- Added `update`, `deleteCustom`, and `countAll` queries to `Item.sq`
- `ShopRepositoryImpl`: Full CRUD for shops, reactive Flow-based queries, inventory management, cascade delete via transactions
- `ItemRepositoryImpl`: Flow-based catalog queries, category/rarity filtering, name search, custom item CRUD, idempotent catalog seeding
- `CatalogItems`: Built-in catalog of 38 original fantasy items across all 10 `ItemCategory` values

## Testing
- `ShopRepositoryImplTest`: 12 tests covering shop CRUD, inventory management, reactive Flow emissions
- `ItemRepositoryImplTest`: 13 tests covering catalog queries, search, custom item CRUD, seeding idempotency
- [x] All tests pass (`./gradlew :data:jvmTest`)

Closes #8